### PR TITLE
Add Configured[FiniteDuration]

### DIFF
--- a/core/src/main/scala/knobs/Configured.scala
+++ b/core/src/main/scala/knobs/Configured.scala
@@ -21,7 +21,7 @@ import scalaz.syntax.applicative._
 import scalaz.std.list._
 import scalaz.std.option._
 import scalaz.{Monad,\/}
-import concurrent.duration.Duration
+import concurrent.duration.{Duration, FiniteDuration}
 
 /**
  * The class of types that can be automatically and safely
@@ -52,6 +52,12 @@ object Configured {
     def apply(a: CfgValue) = a match {
       case CfgDuration(b) => Some(b)
       case _ => None
+    }
+  }
+
+  implicit val configuredFiniteDuration: Configured[FiniteDuration] = new Configured[FiniteDuration]{
+    def apply(a: CfgValue) = configuredDuration(a) collect {
+      case d: FiniteDuration => d
     }
   }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.10.0-SNAPSHOT"
+version in ThisBuild := "3.11.0-SNAPSHOT"


### PR DESCRIPTION
This is one possible resolution to #33. I've gone this route for a
couple reasons:
- It's not a breaking change like making `CfgDuration` wrap a `FiniteDuration` would be.
- I don't think that there's a theoretical reason that an infinite duration _shouldn't_ be allowed, even though there's currently not support for it in the parser.