### PR TITLE
Fix Maven Central link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ Knobs
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/io.verizon.knobs/core_2.11/badge.svg)](https://maven-badges.herokuapp.com/maven-central/io.verizon.knobs/core_2.11)
 [![codecov](https://codecov.io/gh/Verizon/knobs/branch/master/graph/badge.svg)](https://codecov.io/gh/Verizon/knobs)
 
-Please [view the documentation](http://oncue.github.io/knobs/) for more information, and go to [Maven Central]((http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22io.verizon.knobs%22) for the latest releases.
+Please [view the documentation](http://oncue.github.io/knobs/) for more information, and go to [Maven Central](http://search.maven.org/#search%7Cga%7C1%7Cg%3A%22io.verizon.knobs%22) for the latest releases.


### PR DESCRIPTION
I had an extra parenthesis in there.