### PR TITLE
fixed SysPropsResource prefix config values

### DIFF
--- a/core/src/main/scala/knobs/Pattern.scala
+++ b/core/src/main/scala/knobs/Pattern.scala
@@ -16,6 +16,9 @@
 //: ----------------------------------------------------------------------------
 package knobs
 
+import scalaz.std.string._
+import scalaz.syntax.equal._
+
 /**
   * A pattern that matches a `Name` either exactly or as a prefix.
   */
@@ -25,8 +28,8 @@ sealed trait Pattern {
     case Prefix(s) => Prefix(pfx ++ s)
   }
   final def matches(n: Name): Boolean = this match {
-    case Exact(s) => s == n
-    case Prefix(s) => n startsWith n
+    case Exact(s) => s === n
+    case Prefix(s) => n startsWith s
   }
 }
 

--- a/core/src/test/scala/knobs/Test.scala
+++ b/core/src/test/scala/knobs/Test.scala
@@ -79,6 +79,16 @@ object Test extends Properties("Knobs") {
       cfg.lookup[String]("path.separator").map(_.isDefined)
     }
 
+  lazy val propertiesSubconfigTest: Task[Prop] =
+    withLoad(List(Required(SysPropsResource(Prefix("user"))))) { cfg =>
+      cfg.subconfig("user").lookup[String]("name").map(_.isDefined)
+    }
+
+  lazy val propertiesNegativeTest: Task[Prop] =
+    withLoad(List(Required(SysPropsResource(Prefix("user"))))) { cfg =>
+      cfg.lookup[String]("path.separator").map(_.isEmpty)
+    }
+
   lazy val fallbackTest: Task[Prop] =
     withLoad(List(Required(
       ClassPathResource("foobar.cfg") or
@@ -121,6 +131,10 @@ object Test extends Properties("Knobs") {
   property("import") = importTest.unsafePerformSync
 
   property("load-system-properties") = loadPropertiesTest.unsafePerformSync
+
+  property("system-properties-negative") = propertiesNegativeTest.unsafePerformSync
+
+  property("system-properties-subconfig") = propertiesSubconfigTest.unsafePerformSync
 
   property("load-fallback-chain") = fallbackTest.unsafePerformSync
 


### PR DESCRIPTION
Added two new tests
  1. for checking if only "user" prefixed system properties should be available then looking up "path.separator" should fail
  2. check usage of subconfig given some prefixed system property