### PR TITLE
introduced a ValueError that represents an error caused by a config value that isn't the expected type

### DIFF
--- a/core/src/main/scala/knobs/Config.scala
+++ b/core/src/main/scala/knobs/Config.scala
@@ -36,7 +36,7 @@ case class Config(env: Env) {
 
   /** Look up the value under the key with the given name and error if it doesn't exist */
   def require[A:Configured](name: Name): A =
-    lookup(name).getOrElse(throw KeyError(name))
+    lookup(name).getOrElse(env.get(name).fold(throw KeyError(name))(v => throw ValueError(name, v)))
 }
 
 object Config {

--- a/core/src/main/scala/knobs/MutableConfig.scala
+++ b/core/src/main/scala/knobs/MutableConfig.scala
@@ -118,7 +118,9 @@ case class MutableConfig(root: String, base: BaseConfig) {
    */
   def require[A:Configured](name: Name): Task[A] = for {
     v <- lookup(name)
-    r <- v.map(Task.now(_)).getOrElse(Task.fail(KeyError(name)))
+    r <- v.map(Task.now).getOrElse(
+      getEnv.map(_.get(name).fold(throw KeyError(name))(v => throw ValueError(name, v)))
+    )
   } yield r
 
   /**

--- a/core/src/main/scala/knobs/ValueError.scala
+++ b/core/src/main/scala/knobs/ValueError.scala
@@ -1,0 +1,20 @@
+//: ----------------------------------------------------------------------------
+//: Copyright (C) 2015 Verizon.  All Rights Reserved.
+//:
+//:   Licensed under the Apache License, Version 2.0 (the "License");
+//:   you may not use this file except in compliance with the License.
+//:   You may obtain a copy of the License at
+//:
+//:       http://www.apache.org/licenses/LICENSE-2.0
+//:
+//:   Unless required by applicable law or agreed to in writing, software
+//:   distributed under the License is distributed on an "AS IS" BASIS,
+//:   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//:   See the License for the specific language governing permissions and
+//:   limitations under the License.
+//:
+//: ----------------------------------------------------------------------------
+package knobs
+
+case class ValueError(name: String, value: CfgValue) extends Exception(s"Key '$name' found but value '${value.pretty}' isn't the expected type.")
+


### PR DESCRIPTION
Ideally the error message should also carry the information of the type expected. But that would mean somehow accessing type information on any 'A'.