### PR TITLE
Support commented out config file

### DIFF
--- a/core/src/main/scala/knobs/Config.scala
+++ b/core/src/main/scala/knobs/Config.scala
@@ -50,7 +50,7 @@ object Config {
         case Group(name, gds) => go(pfx + name + ".", m, gds)
         case x => sys.error(s"Unexpected directive: $x")
       })
-    runParser(sansImport, s) match {
+    runParser(topLevel(withImport = false), s) match {
       case Left(e) => left(ParseException(e.message.toString))
       case Right((_, ds)) => right(Config(go("", empty.env, ds)))
     }

--- a/core/src/test/scala/knobs/ParserTest.scala
+++ b/core/src/test/scala/knobs/ParserTest.scala
@@ -1,0 +1,42 @@
+package knobs
+
+import org.scalatest._
+import scalaz.\/-
+
+import ConfigParser.ParserOps
+
+class ParserTest extends FlatSpec with Matchers with Inside {
+
+  "Parser" should "correctly parse config input with only comments" in {
+    val input =
+      """#param1=true
+        |#param2="hello"""".stripMargin
+    ConfigParser.topLevel.parse(input) should be (\/-(Nil))
+  }
+
+  it should "parse a bind preceded by a comment" in {
+    val input = """
+      #Whether to trigger a timeout or not
+      test.timeout=true
+    """
+    val result = ConfigParser.topLevel.parse(input)
+    result should be (\/-(List(Group("test", List(Bind("timeout", CfgBool(true)))))))
+  }
+
+  it should "parse a group directive" in {
+    val input =
+      """ac {
+        |  # fnord
+        |  x=1
+        |
+        |  y=true
+        |
+        |  #blorg
+        |}
+      """.stripMargin
+    val expected = \/-(Group("ac", List(
+      Bind("x", CfgNumber(1)),
+      Bind("y", CfgBool(true)))))
+    ConfigParser.groupDirective(withImport = true).parse(input) should be (expected)
+  }
+}


### PR DESCRIPTION
Modify parser to produce an empty `List[Directive]` if the input is nothing but comments as opposed to failing to parse