### PR TITLE
Fix build for 4.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
       env: SCALAZ_VERSION=7.2.7
     # scala 2.12
     - jdk: oraclejdk8
-      scala: 2.11.8
+      scala: 2.12.1
       env: SCALAZ_VERSION=7.1.11
     - jdk: oraclejdk8
       scala: 2.12.1

--- a/project.sbt
+++ b/project.sbt
@@ -31,3 +31,9 @@ lazy val zookeeper = project.dependsOn(core)
 lazy val docs = project.dependsOn(core, zookeeper)
 
 enablePlugins(DisablePublishingPlugin)
+
+// Some tests set system properties, which results in a
+// ConcurrentModificationException while other tests are iterating
+// over sys.props.  For a stable build, we need to reduce test
+// concurrency to 1 across modules.
+concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,7 +19,7 @@ resolvers += Resolver.url(
     url("http://dl.bintray.com/content/tpolecat/sbt-plugin-releases"))(
         Resolver.ivyStylePatterns)
 
-addSbtPlugin("io.verizon.build" % "sbt-rig" % "1.2.25")
+addSbtPlugin("io.verizon.build" % "sbt-rig" % "2.0.29")
 
 // docs
 addSbtPlugin("com.typesafe.sbt"  % "sbt-site"    % "0.8.1")


### PR DESCRIPTION
- Use an sbt-rig that can publish with -scalaz-7.x prefix
- Add missing _2.12 / -scalaz-7.1 build to matrix