### PR TITLE
update fs2 to 1.0.0-M1

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,7 +4,7 @@ resolvers ++= Seq(
 
 libraryDependencies ++= {
   Seq(
-    "co.fs2"            %% "fs2-core" % "0.10.1",
+    "co.fs2"            %% "fs2-core" % "1.0.0-M1",
     "io.verizon.ermine" %% "parser"   % "0.5.8"
   )
 }

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -4,7 +4,7 @@ resolvers ++= Seq(
 
 libraryDependencies ++= {
   Seq(
-    "co.fs2"            %% "fs2-core" % "1.0.0-M1",
+    "co.fs2"            %% "fs2-core" % "1.0.0",
     "io.verizon.ermine" %% "parser"   % "0.5.8"
   )
 }

--- a/core/src/main/scala/knobs/MutableConfig.scala
+++ b/core/src/main/scala/knobs/MutableConfig.scala
@@ -20,7 +20,7 @@ import cats._
 import cats.effect.{Effect, Sync, Concurrent, ConcurrentEffect}
 import cats.implicits._
 import fs2.Stream
-import fs2.async.signalOf
+import fs2.concurrent.SignallingRef
 
 /** Mutable, reloadable, configuration data */
 case class MutableConfig[F[_]](root: String, base: BaseConfig[F]) {
@@ -167,7 +167,7 @@ case class MutableConfig[F[_]](root: String, base: BaseConfig[F]) {
    * the given pattern
    */
   def changes(p: Pattern)(implicit F: Concurrent[F]): Stream[F, (Name, Option[CfgValue])] = {
-    val signal = signalOf[F, (Name, Option[CfgValue])](("", None)) // TP: Not sure about the soundness of this default?
+    val signal = SignallingRef[F, (Name, Option[CfgValue])](("", None)) // TP: Not sure about the soundness of this default?
 
     Stream.eval {
       for {

--- a/core/src/main/scala/knobs/MutableConfig.scala
+++ b/core/src/main/scala/knobs/MutableConfig.scala
@@ -17,12 +17,10 @@
 package knobs
 
 import cats._
-import cats.effect.{Effect, Sync}
+import cats.effect.{Effect, Sync, Concurrent, ConcurrentEffect}
 import cats.implicits._
 import fs2.Stream
 import fs2.async.signalOf
-
-import scala.concurrent.ExecutionContext
 
 /** Mutable, reloadable, configuration data */
 case class MutableConfig[F[_]](root: String, base: BaseConfig[F]) {
@@ -41,23 +39,23 @@ case class MutableConfig[F[_]](root: String, base: BaseConfig[F]) {
    * just the local section. Any overridden properties set with `addProperties`
    * will disappear.
    */
-  def reload(implicit F: Effect[F]): F[Unit] = base.reload
+  def reload(implicit F: ConcurrentEffect[F]): F[Unit] = base.reload
 
   /**
    * Add additional files to this `MutableConfig`, causing it to be reloaded to
    * add their contents.
    */
-  def add(paths: List[KnobsResource])(implicit F: Effect[F]): F[Unit] =
+  def add(paths: List[KnobsResource])(implicit F: ConcurrentEffect[F]): F[Unit] =
     addGroups(paths.map(x => ("", x)))
 
   /**
    * Add additional files to named groups in this `MutableConfig`, causing it to be
    * reloaded to add their contents.
    */
-  def addGroups(paths: List[(Name, KnobsResource)])(implicit F: Effect[F]): F[Unit] = {
+  def addGroups(paths: List[(Name, KnobsResource)])(implicit F: ConcurrentEffect[F]): F[Unit] = {
     def fix[A](p: (String, A)) = (addDot(p._1), p._2)
     for {
-      _ <- base.paths.modify(prev => prev ++ paths.map(fix))
+      _ <- base.paths.update(prev => prev ++ paths.map(fix))
       _ <- base.reload
     } yield ()
   }
@@ -68,11 +66,11 @@ case class MutableConfig[F[_]](root: String, base: BaseConfig[F]) {
    * will be lost.
    */
   def addEnv(props: Env)(implicit F: Effect[F]): F[Unit] = for {
-    p <- base.cfgMap.modify2 { m =>
+    p <- base.cfgMap.modify { m =>
       val mp = m ++ props.map { case (k, v) => (root + k, v) }
       (mp, (m, mp))
     }
-    (_, (m, mp)) = p
+    (m, mp) = p
     subs <- base.subs.get
     _ <- notifySubscribers(m, mp, subs)
   } yield ()
@@ -156,19 +154,19 @@ case class MutableConfig[F[_]](root: String, base: BaseConfig[F]) {
    * Subscribe to notifications. The given handler will be invoked when any
    * change occurs to a configuration property that matches the pattern.
    */
-  def subscribe(p: Pattern, h: ChangeHandler[F])(implicit F: Apply[F]): F[Unit] =
-    base.subs.modify { map =>
+  def subscribe(p: Pattern, h: ChangeHandler[F]): F[Unit] =
+    base.subs.update { map =>
       map.get(p.local(root)) match {
         case None           => map + ((p.local(root), List(h)))
         case Some(existing) => map + ((p.local(root), existing ++ List(h)))
       }
-    }.void
+    }
 
   /**
    * A process that produces chages to the configuration properties that match
    * the given pattern
    */
-  def changes(p: Pattern)(implicit F: Effect[F], ec: ExecutionContext): Stream[F, (Name, Option[CfgValue])] = {
+  def changes(p: Pattern)(implicit F: Concurrent[F]): Stream[F, (Name, Option[CfgValue])] = {
     val signal = signalOf[F, (Name, Option[CfgValue])](("", None)) // TP: Not sure about the soundness of this default?
 
     Stream.eval {

--- a/core/src/main/scala/knobs/Resource.scala
+++ b/core/src/main/scala/knobs/Resource.scala
@@ -232,7 +232,7 @@ object Resource {
       ds <- load(path)
       rs <- recursiveImports(path.worth, ds)
       es <- (path.worth :: rs).traverse(f => watchEvent(f.toPath))
-    } yield (ds, Stream.emits(es.map(_.map(_ => ()))).joinUnbounded)
+    } yield (ds, Stream.emits(es.map(_.map(_ => ()))).parJoinUnbounded)
   }
 
   implicit def uriResource: Resource[URI] = new Resource[URI] {

--- a/core/src/main/scala/knobs/package.scala
+++ b/core/src/main/scala/knobs/package.scala
@@ -17,8 +17,7 @@
 import cats.effect._
 import cats.implicits._
 import fs2.Stream
-import fs2.async.Ref
-import scala.concurrent.ExecutionContext
+import cats.effect.concurrent.Ref
 
 package object knobs {
   import Resource._
@@ -55,9 +54,8 @@ package object knobs {
    * first time they are opened, so you can specify a file name such as
    * `"$(HOME)/myapp.cfg"`.
    */
-  def load[F[_]: Effect](files: List[KnobsResource],
-           pool: ExecutionContext = Resource.notificationPool): F[MutableConfig[F]] =
-    loadp(files.map(f => ("", f)), pool).map(MutableConfig("", _))
+  def load[F[_]: ConcurrentEffect](files: List[KnobsResource]): F[MutableConfig[F]] =
+    loadp(files.map(f => ("", f))).map(MutableConfig("", _))
 
   /**
    * Create an immutable `Config` from the contents of the named files. Throws an
@@ -67,22 +65,20 @@ package object knobs {
    * first time they are opened, so you can specify a file name such as
    * `"$(HOME)/myapp.cfg"`.
    */
-  def loadImmutable[F[_]: Effect](files: List[KnobsResource],
-                    pool: ExecutionContext = Resource.notificationPool): F[Config] =
+  def loadImmutable[F[_]: ConcurrentEffect](files: List[KnobsResource]): F[Config] =
     load(files.map(_.map {
       case WatchBox(b, w) => ResourceBox(b)(w)
       case x => x
-    }), pool).flatMap(_.immutable)
+    })).flatMap(_.immutable)
 
   /**
    * Create a `MutableConfig` from the contents of the named files, placing them
    * into named prefixes.
    */
-  def loadGroups[F[_]: Effect](files: List[(Name, KnobsResource)],
-                 pool: ExecutionContext = Resource.notificationPool): F[MutableConfig[F]] =
-    loadp(files, pool).map(MutableConfig("", _))
+  def loadGroups[F[_]: ConcurrentEffect](files: List[(Name, KnobsResource)]): F[MutableConfig[F]] =
+    loadp(files).map(MutableConfig("", _))
 
-  private [knobs] def loadFiles[F[_]: Effect](paths: List[KnobsResource]): F[Loaded[F]] = {
+  private [knobs] def loadFiles[F[_]: ConcurrentEffect](paths: List[KnobsResource]): F[Loaded[F]] = {
     def go(seen: Loaded[F], path: KnobsResource): F[Loaded[F]] = {
       def notSeen(n: KnobsResource): Boolean = seen.get(n).isEmpty
       for {
@@ -98,14 +94,13 @@ package object knobs {
   }
 
   private [knobs] def loadp[F[_]](
-    paths: List[(Name, KnobsResource)],
-    pool: ExecutionContext = Resource.notificationPool)(implicit F: Effect[F]): F[BaseConfig[F]] = {
-      implicit val implicitPool = pool
+    paths: List[(Name, KnobsResource)]
+  )(implicit F: ConcurrentEffect[F]): F[BaseConfig[F]] = {
       for {
         loaded <- loadFiles(paths.map(_._2))
-        p <- Ref(paths)
-        m <- flatten(paths, loaded).flatMap(Ref(_))
-        s <- Ref(Map[Pattern, List[ChangeHandler[F]]]())
+        p <- Ref[F].of(paths)
+        m <- flatten(paths, loaded).flatMap(Ref[F].of(_))
+        s <- Ref[F].of(Map[Pattern, List[ChangeHandler[F]]]())
         bc = BaseConfig(paths = p, cfgMap = m, subs = s)
         ticks = Stream.emits(loaded.values.map(_._2).toSeq).joinUnbounded
         _ <- F.delay(F.runAsync(ticks.evalMap(_ => bc.reload).compile.drain)(_ => IO.unit).unsafeRunSync)
@@ -222,7 +217,7 @@ package object knobs {
       implicitly[Resource[R]].load(Required(r)).flatMap(dds =>
         recursiveImports(r, dds))))
 
-  private [knobs] def loadOne[F[_]: Effect](path: KnobsResource): F[(List[Directive], Stream[F, Unit])] = {
+  private [knobs] def loadOne[F[_]: ConcurrentEffect](path: KnobsResource): F[(List[Directive], Stream[F, Unit])] = {
     val box = path.worth
     val r: box.R = box.resource
     box.watchable match {

--- a/core/src/main/scala/knobs/package.scala
+++ b/core/src/main/scala/knobs/package.scala
@@ -102,7 +102,7 @@ package object knobs {
         m <- flatten(paths, loaded).flatMap(Ref[F].of(_))
         s <- Ref[F].of(Map[Pattern, List[ChangeHandler[F]]]())
         bc = BaseConfig(paths = p, cfgMap = m, subs = s)
-        ticks = Stream.emits(loaded.values.map(_._2).toSeq).joinUnbounded
+        ticks = Stream.emits(loaded.values.map(_._2).toSeq).parJoinUnbounded
         _ <- F.delay(F.runAsync(ticks.evalMap(_ => bc.reload).compile.drain)(_ => IO.unit).unsafeRunSync)
       } yield bc
     }

--- a/core/src/test/scala/knobs/FileWatcherTest.scala
+++ b/core/src/test/scala/knobs/FileWatcherTest.scala
@@ -16,7 +16,7 @@
 //: ----------------------------------------------------------------------------
 package knobs
 
-import fs2.async.Ref
+import cats.effect.concurrent.Ref
 import java.nio.file.{ Files, Paths }
 import java.util.concurrent.CountDownLatch
 import org.scalacheck._
@@ -32,12 +32,12 @@ object FileWatcherTests extends Properties("FileWatch") {
     val mutantPath = Paths.get(mutantUri)
     val latch = new CountDownLatch(1)
     val prg = for {
-      ref <- Ref[IO, String]("")
+      ref <- Ref.of[IO, String]("")
       _   <- IO(Files.write(mutantPath, "foo = \"bletch\"\n".getBytes))
       cfg <- load[IO](List(Required(FileResource(mutantPath.toFile))))
       _ <- cfg.subscribe(Exact("foo"), {
         case ("foo", Some(t: CfgText)) =>
-          ref.setSync(t.pretty).flatMap(_ => IO(latch.countDown))
+          ref.set(t.pretty).flatMap(_ => IO(latch.countDown))
         case _ => {
           IO(latch.countDown)
         }

--- a/core/src/test/scala/knobs/FileWatcherTest.scala
+++ b/core/src/test/scala/knobs/FileWatcherTest.scala
@@ -21,11 +21,13 @@ import java.nio.file.{ Files, Paths }
 import java.util.concurrent.CountDownLatch
 import org.scalacheck._
 import org.scalacheck.Prop._
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 
 object FileWatcherTests extends Properties("FileWatch") {
+
+  implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 
   property("file watch") = {
     val mutantUri = Thread.currentThread.getContextClassLoader.getResource("mutant.cfg").toURI

--- a/core/src/test/scala/knobs/Test.scala
+++ b/core/src/test/scala/knobs/Test.scala
@@ -19,6 +19,7 @@ package knobs
 import org.scalacheck._
 import Prop._
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import cats.effect.IO
 import cats.implicits._

--- a/core/src/test/scala/knobs/Test.scala
+++ b/core/src/test/scala/knobs/Test.scala
@@ -19,12 +19,14 @@ package knobs
 import org.scalacheck._
 import Prop._
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.implicits._
 
 object Test extends Properties("Knobs") {
+
+  implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 
   // TODO remove when available in Scalacheck
   // https://github.com/rickynils/scalacheck/pull/284

--- a/zookeeper/src/main/scala/knobs/Zookeeper.scala
+++ b/zookeeper/src/main/scala/knobs/Zookeeper.scala
@@ -69,7 +69,7 @@ object ZooKeeper {
       reloads <- F.delay { Stream.emits(node.worth +: rs).map {
         case ZNode(c, path) => watchEvent(c, path).map(_ => ())
       }}
-    } yield (ds, reloads.joinUnbounded)
+    } yield (ds, reloads.parJoinUnbounded)
 
     def show(t: ZNode): String = t.toString
   }

--- a/zookeeper/src/main/scala/knobs/Zookeeper.scala
+++ b/zookeeper/src/main/scala/knobs/Zookeeper.scala
@@ -22,9 +22,7 @@ import org.apache.curator.retry._
 import org.apache.zookeeper.WatchedEvent
 import org.apache.zookeeper.Watcher.Event.EventType._
 
-import scala.concurrent.ExecutionContext
-
-import cats.effect.{Async, Effect, Sync}
+import cats.effect.{Async, Sync, ConcurrentEffect, Concurrent}
 import cats.implicits._
 import fs2.Stream
 
@@ -56,7 +54,7 @@ object ZooKeeper {
       } catch { case e: Exception => k(Left(e)) }
     }).repeat
 
-  implicit def zkResource(implicit ec: ExecutionContext): Watchable[ZNode] = new Watchable[ZNode] {
+  implicit def zkResource: Watchable[ZNode] = new Watchable[ZNode] {
     def resolve(r: ZNode, child: Path): ZNode =
       r.copy(path = Resource.resolveName(r.path, child))
     def load[F[_]](node: Worth[ZNode])(implicit F: Sync[F]) = {
@@ -65,7 +63,7 @@ object ZooKeeper {
         new String(c.getData.forPath(path).map(_.toChar))
       })
     }
-    def watch[F[_]](node: Worth[ZNode])(implicit F: Effect[F]) = for {
+    def watch[F[_]](node: Worth[ZNode])(implicit F: Concurrent[F]) = for {
       ds <- load(node)
       rs <- recursiveImports(node.worth, ds)
       reloads <- F.delay { Stream.emits(node.worth +: rs).map {
@@ -76,7 +74,7 @@ object ZooKeeper {
     def show(t: ZNode): String = t.toString
   }
 
-  private def doZK[F[_]](config: List[KnobsResource])(implicit F: Effect[F], ec: ExecutionContext): F[(ResourceBox, CuratorFramework)] = {
+  private def doZK[F[_]](config: List[KnobsResource])(implicit F: ConcurrentEffect[F]): F[(ResourceBox, CuratorFramework)] = {
 
     val retryPolicy = new ExponentialBackoffRetry(1000, 3)
 
@@ -113,7 +111,7 @@ object ZooKeeper {
    * } yield () }.run
    * ```
    */
-  def withDefault[F[_]](k: ResourceBox => F[Unit])(implicit F: Effect[F], ec: ExecutionContext): F[Unit] = safe(k)
+  def withDefault[F[_]](k: ResourceBox => F[Unit])(implicit F: ConcurrentEffect[F]): F[Unit] = safe(k)
 
   /**
    * IO-based API. Works just like `withDefault` except it loads configuration from
@@ -130,9 +128,9 @@ object ZooKeeper {
    * } yield () }.run
    * ```
    */
-  def fromResource[F[_]](customConfig: List[KnobsResource])(k: ResourceBox => F[Unit])(implicit F: Effect[F], ec: ExecutionContext): F[Unit] = safe(k, customConfig)
+  def fromResource[F[_]](customConfig: List[KnobsResource])(k: ResourceBox => F[Unit])(implicit F: ConcurrentEffect[F]): F[Unit] = safe(k, customConfig)
 
-  protected def safe[F[_]](k: ResourceBox => F[Unit], config: List[KnobsResource] = null)(implicit F: Effect[F], ec: ExecutionContext): F[Unit] = for {
+  protected def safe[F[_]](k: ResourceBox => F[Unit], config: List[KnobsResource] = null)(implicit F: ConcurrentEffect[F]): F[Unit] = for {
     p <- doZK(config)
     (box, c) = p
     _ <- k(box)

--- a/zookeeper/src/test/scala/knobs/ZookeeperTest.scala
+++ b/zookeeper/src/test/scala/knobs/ZookeeperTest.scala
@@ -17,7 +17,7 @@
 package knobs
 
 import Resource._
-import cats.effect.IO
+import cats.effect.{ContextShift, IO}
 import cats.effect.concurrent.Ref
 import java.util.concurrent.CountDownLatch
 import org.apache.curator.framework._
@@ -25,9 +25,11 @@ import org.apache.curator.retry._
 import org.apache.curator.test._
 import org.scalacheck.Prop._
 import org.scalacheck._
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.ExecutionContext
 
 object ZooKeeperTests extends Properties("ZooKeeper") {
+
+  implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
 
   val retryPolicy = new ExponentialBackoffRetry(1000, 3)
 


### PR DESCRIPTION
Most changes are `s/Effect/ConcurrentEffect/g`.  Also `ExecutionContext` is now required only when resolving `ConcurrentEffect` which makes `notificationPool` useless.